### PR TITLE
Challenge View Upgrade

### DIFF
--- a/Sources/App/AppView.swift
+++ b/Sources/App/AppView.swift
@@ -12,7 +12,6 @@ import HopKit
 import FeatureChallenge
 import FeatureHome
 
-@available(macOS 10.15, *)
 struct AppView: View {
     @State var hasOnboarded = false
     @State var journey: Journey? = nil
@@ -27,7 +26,7 @@ struct AppView: View {
         }
     }
 }
-@available(macOS 10.15, *)
+
 struct AppView_Previews: PreviewProvider {
     static var previews: some View {
         AppView()

--- a/Sources/LibEngine/Resources/wikipediaUserStyles.js
+++ b/Sources/LibEngine/Resources/wikipediaUserStyles.js
@@ -14,3 +14,5 @@ document.head.appendChild(style)
 var searchIcon = document.getElementById("searchIcon");
 searchIcon.style.display = "none";
 
+var hamburgerMenu = document.getElementById("mw-mf-main-menu-button");
+hamburgerMenu.style.display = "none";


### PR DESCRIPTION
- Chevron buttons added to the search bar that allow the user to traverse the results of their search query.
- Destination title added to the trailing top section of the page.
- Clock counter for time elapsed so far add to trailing bottom section of the view.
- Overlay problem of their containers extended far past content was fixed.
- Wikipedia hamburger menu hidden from user.


![Screen Shot 2023-08-07 at 00 51 15 AM](https://github.com/boek/WikiHop/assets/101987676/0720e80d-3136-4780-97b3-3be705a1ad18)